### PR TITLE
Allowing greater versions of illuminate for #8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.0.*",
-        "illuminate/config": "5.0.*",
-        "illuminate/routing": "5.0.*",
-        "illuminate/session": "5.0.*",
+        "illuminate/support": ">=5.0.*",
+        "illuminate/config": ">=5.0.*",
+        "illuminate/routing": ">=5.0.*",
+        "illuminate/session": ">=5.0.*",
         "guzzlehttp/guzzle": "~5.2",
         "facebook/php-sdk-v4" : "~4.0"
     },


### PR DESCRIPTION
Possible fix/solution for Laravel 5.4 support. If more work is required this pull request can be closed and effort can be made to support Laravel 5.4 on issue #8 